### PR TITLE
support multiple python tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ Run ```depsize``` to get a description of the tool
 
 ```bash
 > depsize
-depsize: Get the total size of installed python dependencies in MB.
- Use 'depsize total' to get a summary including total size and the largest packages.
- Use 'depsize --o FILE' to export as JSON, f.ex 'depsize --o data/packages.json'
+depsize: Get the total size of installed python dependencies in megabytes (MB).
+    Run 'depsize total' to get total size of dependencies, including the largest
+    Run 'depsize --o FILE' to export dependencies as JSON,
+        f.ex 'depsize --o data/packages.json'
+    Add '--from' to 'depsize total' and 'depsize --o' to measure size of main and dev dependencies,
+        f.ex 'depsize total --from requirements-main.txt'
 ```
 
 Run ```depsize total``` to print the size of all packages in MB, and name the largest:
@@ -117,6 +120,7 @@ Dependencies written to data/packages.json
 Example JSON file contents:
 
 <details>
+
 ```json
 [
   {
@@ -276,6 +280,7 @@ Example JSON file contents:
   }
 ]
 ```
+
 </details>
 
 ## Developing locally

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # depsize
 
-This python package helps you measure the disk space used by your python dependencies. The purpose of this package is to help you understand how much each package contributes to the size of your app, and to help you find ways to reduce the size of the app.
+The depsize package helps you measure the disk space used by your python dependencies. The purpose of this package is to help you understand how much each package contributes to the size of your app, and to help you find ways to reduce the size of the app.
+
+Depsize supports uv and pip, and although it currently cannot parse dependencies for poetry and conda, it can tell you how to do it - and use the results with depsize.
 
 When used in combination with `docker image history` this tool helps you find ways to reduce the total size of the docker image.
 

--- a/justfile
+++ b/justfile
@@ -54,3 +54,7 @@ pypi_publish:
 # publish on test python package index
 testpypi_publish:
     uv publish --index testpypi --token {{TESTPYPI_TOKEN}}
+
+# run all tests with pytest
+run_tests:
+    pytest tests/ -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ license = {file = "LICENSE"}
 [dependency-groups]
 dev = [
     "ipykernel>=6.29.5",
+    "pytest>=8.3.5",
     "ruff>=0.11.12",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "depsize"
-version = "0.1.6"
+version = "0.1.7"
 description = "A package that tells you the size of your dependencies in Megabytes!"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "depsize"
-version = "0.1.7"
+version = "0.1.8"
 description = "A package that tells you the size of your dependencies in Megabytes!"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,10 +14,14 @@ debugpy==1.8.14
     # via ipykernel
 decorator==5.2.1
     # via ipython
+exceptiongroup==1.3.0
+    # via pytest
 executing==2.2.0
     # via stack-data
 importlib-metadata==8.5.0
     # via jupyter-client
+iniconfig==2.1.0
+    # via pytest
 ipykernel==6.29.5
     # via depsize (pyproject.toml:dev)
 ipython==8.12.3
@@ -37,7 +41,9 @@ matplotlib-inline==0.1.7
 nest-asyncio==1.6.0
     # via ipykernel
 packaging==25.0
-    # via ipykernel
+    # via
+    #   ipykernel
+    #   pytest
 parso==0.8.4
     # via jedi
 pexpect==4.9.0
@@ -46,6 +52,8 @@ pickleshare==0.7.5
     # via ipython
 platformdirs==4.3.6
     # via jupyter-core
+pluggy==1.5.0
+    # via pytest
 prompt-toolkit==3.0.51
     # via ipython
 psutil==7.0.0
@@ -56,6 +64,8 @@ pure-eval==0.2.3
     # via stack-data
 pygments==2.19.1
     # via ipython
+pytest==8.3.5
+    # via depsize (pyproject.toml:dev)
 python-dateutil==2.9.0.post0
     # via jupyter-client
 pyzmq==26.4.0
@@ -68,6 +78,8 @@ six==1.17.0
     # via python-dateutil
 stack-data==0.6.3
     # via ipython
+tomli==2.2.1
+    # via pytest
 tornado==6.4.2
     # via
     #   ipykernel
@@ -81,7 +93,9 @@ traitlets==5.14.3
     #   jupyter-core
     #   matplotlib-inline
 typing-extensions==4.13.2
-    # via ipython
+    # via
+    #   exceptiongroup
+    #   ipython
 wcwidth==0.2.13
     # via prompt-toolkit
 zipp==3.20.2

--- a/src/depsize/depsize.py
+++ b/src/depsize/depsize.py
@@ -96,15 +96,21 @@ def get_pip_packages():
     """
     if shutil.which("pip"):
         # pip installed
-        command = ["pip", "list", "--format=json"]
+        cmd = ["pip", "list", "--format=json"]
     elif shutil.which("uv"):
         # uv installed
-        command = ["uv", "pip", "list", "--format=json"]
+        cmd = ["uv", "pip", "list", "--format=json"]
     else:
         # neither installed
-        print(f"Error: Couldn't find pip or uv in PATH. Cannot produce list of dependencies.")
+        print(
+            "Error: Couldn't find pip or uv in PATH.\n"
+            "Cannot produce list of dependencies.\n"
+            "If you are using Poetry, run 'poetry export --format=requirements.txt > requirements.txt'\n"
+            "If you are using Conda, run 'conda list' or export a requirements.txt equivalent.\n"
+            "Then run: depsize --from requirements.txt",
+            file=sys.stderr)
 
-    res = subprocess.run(command, capture_output=True, text=True)
+    res = subprocess.run(cmd, capture_output=True, text=True)
 
     if res.returncode != 0:
         print(f"Error running {' '.join(command)}:\n{res.stderr}")

--- a/src/depsize/depsize.py
+++ b/src/depsize/depsize.py
@@ -4,6 +4,7 @@ import subprocess
 import json
 import argparse
 import shutil
+import sys
 from pathlib import Path
 from typing import List
 

--- a/src/depsize/depsize.py
+++ b/src/depsize/depsize.py
@@ -128,7 +128,7 @@ def get_pip_packages():
     res = subprocess.run(cmd, capture_output=True, text=True)
 
     if res.returncode != 0:
-        print(f"[depsize] Command failed {' '.join(cmd)}:\n{res.stderr}")
+        print(f"[depsize] Package manager command failed with code {res.returncode}")
         return []
 
     try:

--- a/src/depsize/depsize.py
+++ b/src/depsize/depsize.py
@@ -4,7 +4,6 @@ import subprocess
 import json
 import argparse
 import shutil
-import sys
 from pathlib import Path
 from typing import List
 
@@ -123,9 +122,9 @@ def get_pip_packages():
     else:
         # neither installed
         print(
-            "[depsize] No supported package manager found. Looked for pip, uv, poetry and conda using 'which'",
-            file=sys.stderr)
-
+            "[depsize] No supported package manager found. Looked for pip, uv, poetry and conda using 'which'")
+        return []
+    
     res = subprocess.run(cmd, capture_output=True, text=True)
 
     if res.returncode != 0:

--- a/src/depsize/depsize.py
+++ b/src/depsize/depsize.py
@@ -10,10 +10,6 @@ from typing import List
 
 
 # %%
-class FakeResult:
-    def __init__(self, stdout="", returncode=0):
-        self.stdout = stdout
-        self.returncode = returncode
 
 def get_package_size(package_path: Path) -> float:
     """

--- a/src/depsize/depsize.py
+++ b/src/depsize/depsize.py
@@ -113,7 +113,7 @@ def get_pip_packages():
     res = subprocess.run(cmd, capture_output=True, text=True)
 
     if res.returncode != 0:
-        print(f"Error running {' '.join(command)}:\n{res.stderr}")
+        print(f"Error running {' '.join(cmd)}:\n{res.stderr}")
         return []
 
     try:

--- a/src/depsize/depsize.py
+++ b/src/depsize/depsize.py
@@ -10,6 +10,11 @@ from typing import List
 
 
 # %%
+class FakeResult:
+    def __init__(self, stdout="", returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+
 def get_package_size(package_path: Path) -> float:
     """
     Get the size of a package (directory or file) in MB.

--- a/src/depsize/depsize.py
+++ b/src/depsize/depsize.py
@@ -95,32 +95,46 @@ def get_pip_packages():
 
     If main_only is True, limits to the main group (excluding dev).
     """
+    cmd = None
+
     if shutil.which("pip"):
         # pip installed
         cmd = ["pip", "list", "--format=json"]
     elif shutil.which("uv"):
         # uv installed
         cmd = ["uv", "pip", "list", "--format=json"]
+    elif shutil.which("poetry"):
+        print(
+            "[depsize] detected poetry, but it does not support listing packages.\n"
+            "Please run:\n"
+            "   poetry export --without-hashes -f requirements.txt > requirements.txt\n"
+            "   and then pass that file to depsize using --from."
+        )
+        return []
+    elif shutil.which("conda"):
+        print(
+            "[depsize] detected conda, but it does not support listing packages.\n"
+            "Please run:\n"
+            "   conda list --export > requirements.txt\n"
+            "   and then pass that file to depsize using --from."
+        )
+        return []
     else:
         # neither installed
         print(
-            "Error: Couldn't find pip or uv in PATH.\n"
-            "Cannot produce list of dependencies.\n"
-            "If you are using Poetry, run 'poetry export --format=requirements.txt > requirements.txt'\n"
-            "If you are using Conda, run 'conda list' or export a requirements.txt equivalent.\n"
-            "Then run: depsize --from requirements.txt",
+            "[depsize] No supported package manager found. Looked for pip, uv, poetry and conda using 'which'",
             file=sys.stderr)
 
     res = subprocess.run(cmd, capture_output=True, text=True)
 
     if res.returncode != 0:
-        print(f"Error running {' '.join(cmd)}:\n{res.stderr}")
+        print(f"[depsize] Command failed {' '.join(cmd)}:\n{res.stderr}")
         return []
 
     try:
         packages = json.loads(res.stdout)
     except json.JSONDecodeError:
-        print("Error: Failed to parse output")
+        print("[depsize] Error: Failed to parse output")
         return []
 
     return packages

--- a/src/depsize/depsize.py
+++ b/src/depsize/depsize.py
@@ -10,6 +10,7 @@ from typing import List
 
 # %%
 
+
 def get_package_size(package_path: Path) -> float:
     """
     Get the size of a package (directory or file) in MB.
@@ -122,9 +123,10 @@ def get_pip_packages():
     else:
         # neither installed
         print(
-            "[depsize] No supported package manager found. Looked for pip, uv, poetry and conda using 'which'")
+            "[depsize] No supported package manager found. Looked for pip, uv, poetry and conda using 'which'"
+        )
         return []
-    
+
     res = subprocess.run(cmd, capture_output=True, text=True)
 
     if res.returncode != 0:

--- a/tests/test_get_pip_packages.py
+++ b/tests/test_get_pip_packages.py
@@ -74,3 +74,14 @@ def test_invalid_json(monkeypatch, capsys):
     """
     Should handle invalid JSON from subprocess
     """
+    monkeypatch.setattr(shutil, "which", lambda cmd: cmd == "uv")
+
+    def fake_run(*args, **kwargs):
+        return FakeResult("not a json", 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = get_pip_packages()
+    assert result == []
+
+    

--- a/tests/test_get_pip_packages.py
+++ b/tests/test_get_pip_packages.py
@@ -14,120 +14,37 @@ def test_uv_installed(monkeypatch):
     """
     Should run 'uv pip list' when uv is found
     """
+    monkeypatch.setattr(shutil, "which", lambda cmd: cmd == "uv")
 
-    def fake_which(cmd):
-        return "/usr/local/bin/uv" if cmd == "uv" else None
+    def fake_run(*args, **kwargs):
+        return FakeResult('[{"name": "foo", "version": "1.0.0"}]', 0)
 
-    def fake_run(cmd, capture_output=True, text=True):
-        assert cmd[0] == "uv"
-        class FakeResult:
-            stdout = '[{"name": "foo", "version": "1.0.0"}]'
-        return FakeResult()
-
-    monkeypatch.setattr(shutil, "which", fake_which)
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    pkgs = get_pip_packages()
-    assert isinstance(pkgs, list)
-    assert pkgs[0]["name"] == "foo"
+    result = get_pip_packages()
+    assert result == [{"name": "foo", "version": "1.0.0"}]
 
 def test_pip_installed_if_uv_not_found(monkeypatch):
     """
     Should fallback to 'pip list' if uv is not found
     """
 
-    def fake_which(cmd):
-        if cmd == "uv":
-            return None
-        if cmd == "pip":
-            return "/usr/local/bin/pip"
-        return None
-    
-    def fake_run(cmd, capture_output=True, text=True):
-        assert cmd[0] == "pip"
-        class FakeResult:
-            stdout = '[{"name":"bar", "version": "2.0.0."}]'
-        return FakeResult()
-    
-    monkeypatch.setattr(shutil, "which", fake_which)
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    pkgs = get_pip_packages()
-    assert isinstance(pkgs, list)
-    assert pkgs[0]["name"] == "bar"
-
 def test_poetry_fallback_message(monkeypatch, capsys):
     """
     Should print an error message if poetry is found but not pip or uv
     """
-
-    def fake_which(cmd):
-        if cmd in ["uv", "pip"]:
-            return None
-        if cmd == "poetry":
-            return "/usr/local/bin/poetry"
-        return None
-
-    monkeypatch.setattr(shutil, "which", fake_which)
-
-    pkgs = get_pip_packages()
-    captured = capsys.readouterr()
-    assert "Poetry detected" in captured.out
-    assert pkgs == []
 
 def test_conda_fallback_message(monkeypatch, capsys):
     """
     Should print an error message if conda is found but not pip or uv
     """
 
-    def fake_which(cmd):
-        if cmd in ["uv", "pip"]:
-            return None
-        if cmd == "conda":
-            return "/usr/local/bin/conda"
-        return None
-
-    monkeypatch.setattr(shutil, "which", fake_which)
-
-    pkgs = get_pip_packages()
-    captured = capsys.readouterr()
-    assert "Conda detected" in captured.out
-    assert pkgs == []
-
 def test_nothing_found(monkeypatch, capsys):
     """
     Should print an error if no tool is found
     """
 
-    def fake_which(cmd):
-        return None
-
-    monkeypatch.setattr(shutil, "which", fake_which)
-
-    pkgs = get_pip_packages()
-    captured = capsys.readouterr()
-    assert "No supported package manager found" in captured.out
-    assert pkgs == []
-
 def test_invalid_json(monkeypatch, capsys):
     """
     Should handle invalid JSON from subprocess
     """
-
-    def fake_which(cmd):
-        if cmd == "uv":
-            return "/usr/local/bin/uv"
-        return None
-    
-    def fake_run(cmd, capture_output=True, text=True):
-        class FakeResult:
-            stdout = "Not JSON"
-        return FakeResult()
-    
-    monkeypatch.setattr(shutil, "which", fake_which)
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    pkgs = get_pip_packages()
-    captured = capsys.readouterr()
-    assert "Error parsing JSON output" in captured.out
-    assert pkgs == []

--- a/tests/test_get_pip_packages.py
+++ b/tests/test_get_pip_packages.py
@@ -1,0 +1,128 @@
+# %%
+import shutil
+import subprocess
+
+from depsize.depsize import get_pip_packages
+# %%
+
+def test_uv_installed(monkeypatch):
+    """
+    Should run 'uv pip list' when uv is found
+    """
+
+    def fake_which(cmd):
+        return "/usr/local/bin/uv" if cmd == "uv" else None
+
+    def fake_run(cmd, capture_output=True, text=True):
+        assert cmd[0] == "uv"
+        class FakeResult:
+            stdout = '[{"name": "foo", "version": "1.0.0"}]'
+        return FakeResult()
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+    monkeypatch.setattr(shutil, "which", fake_run)
+
+    pkgs = get_pip_packages()
+    assert isinstance(pkgs, list)
+    assert pkgs[0]["name"] == "foo"
+
+def test_pip_installed_if_uv_not_found(monkeypatch):
+    """
+    Should fallback to 'pip list' if uv is not found
+    """
+
+    def fake_which(cmd):
+        if cmd == "uv":
+            return None
+        if cmd == "pip":
+            return "/usr/local/bin/pip"
+        return None
+    
+    def fake_run(cmd, capture_output=True, text=True):
+        assert cmd[0] == "pip"
+        class FakeResult:
+            stdout = '[{"name":"bar", "version": "2.0.0."}]'
+        return FakeResult()
+    
+    monkeypatch.setattr(shutil, "which", fake_which)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    pkgs = get_pip_packages()
+    assert isinstance(pkgs, list)
+    assert pkgs[0]["name"] == "bar"
+
+def test_poetry_fallback_message(monkeypatch, capsys):
+    """
+    Should print an error message if poetry is found but not pip or uv
+    """
+
+    def fake_which(cmd):
+        if cmd in ["uv", "pip"]:
+            return None
+        if cmd == "poetry":
+            return "/usr/local/bin/poetry"
+        return None
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+
+    pkgs = get_pip_packages()
+    captured = capsys.readouterr()
+    assert "Poetry detected" in captured.out
+    assert pkgs == []
+
+def test_conda_fallback_message(monkeypatch, capsys):
+    """
+    Should print an error message if conda is found but not pip or uv
+    """
+
+    def fake_which(cmd):
+        if cmd in ["uv", "pip"]:
+            return None
+        if cmd == "conda":
+            return "/usr/local/bin/conda"
+        return None
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+
+    pkgs = get_pip_packages()
+    captured = capsys.readouterr()
+    assert "Conda detected" in captured.out
+    assert pkgs == []
+
+def test_nothing_found(monkeypatch, capsys):
+    """
+    Should print an error if no tool is found
+    """
+
+    def fake_which(cmd):
+        return None
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+
+    pkgs = get_pip_packages()
+    captured = capsys.readouterr()
+    assert "No supported package manager found" in captured.out
+    assert pkgs == []
+
+def test_invalid_json(monkeypatch, capsys):
+    """
+    Should handle invalid JSON from subprocess
+    """
+
+    def fake_which(cmd):
+        if cmd == "uv":
+            return "/usr/local/bin/uv"
+        return None
+    
+    def fake_run(cmd, captured_output=True, text=True):
+        class FakeResult:
+            stdout = "Not JSON"
+        return FakeResult()
+    
+    monkeypatch.setattr(shutil, "which", fake_which)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    pkgs = get_pip_packages()
+    captured = capsys.readouterr()
+    assert "Error parsing JSON output" in captured.out
+    assert pkgs == []

--- a/tests/test_get_pip_packages.py
+++ b/tests/test_get_pip_packages.py
@@ -53,6 +53,12 @@ def test_conda_fallback_message(monkeypatch, capsys):
     """
     Should print an error message if conda is found but not pip or uv
     """
+    monkeypatch.setattr(shutil, "which", lambda cmd: cmd == "conda")
+    result = get_pip_packages()
+    captured = capsys.readouterr()
+    assert "conda" in captured.out
+    assert "conda list --export" in captured.out
+    assert result == []
 
 def test_nothing_found(monkeypatch, capsys):
     """

--- a/tests/test_get_pip_packages.py
+++ b/tests/test_get_pip_packages.py
@@ -20,7 +20,7 @@ def test_uv_installed(monkeypatch):
         return FakeResult()
 
     monkeypatch.setattr(shutil, "which", fake_which)
-    monkeypatch.setattr(shutil, "which", fake_run)
+    monkeypatch.setattr(subprocess, "run", fake_run)
 
     pkgs = get_pip_packages()
     assert isinstance(pkgs, list)

--- a/tests/test_get_pip_packages.py
+++ b/tests/test_get_pip_packages.py
@@ -4,6 +4,11 @@ import subprocess
 
 from depsize.depsize import get_pip_packages
 # %%
+class FakeResult:
+    def __init__(self, stdout="", returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+
 
 def test_uv_installed(monkeypatch):
     """

--- a/tests/test_get_pip_packages.py
+++ b/tests/test_get_pip_packages.py
@@ -3,6 +3,8 @@ import shutil
 import subprocess
 
 from depsize.depsize import get_pip_packages
+
+
 # %%
 class FakeResult:
     def __init__(self, stdout="", returncode=0):
@@ -24,6 +26,7 @@ def test_uv_installed(monkeypatch):
     result = get_pip_packages()
     assert result == [{"name": "foo", "version": "1.0.0"}]
 
+
 def test_pip_installed_if_uv_not_found(monkeypatch):
     """
     Should fallback to 'pip list' if uv is not found
@@ -38,6 +41,7 @@ def test_pip_installed_if_uv_not_found(monkeypatch):
     result = get_pip_packages()
     assert result == [{"name": "bar", "version": "2.0.0"}]
 
+
 def test_poetry_fallback_message(monkeypatch, capsys):
     """
     Should print an error message if poetry is found but not pip or uv
@@ -48,6 +52,7 @@ def test_poetry_fallback_message(monkeypatch, capsys):
     assert "poetry" in captured.out
     assert "poetry export" in captured.out
     assert result == []
+
 
 def test_conda_fallback_message(monkeypatch, capsys):
     """
@@ -60,6 +65,7 @@ def test_conda_fallback_message(monkeypatch, capsys):
     assert "conda list --export" in captured.out
     assert result == []
 
+
 def test_nothing_found(monkeypatch, capsys):
     """
     Should print an error if no tool is found
@@ -69,6 +75,7 @@ def test_nothing_found(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "No supported package manager" in captured.out
     assert result == []
+
 
 def test_invalid_json(monkeypatch, capsys):
     """
@@ -84,10 +91,12 @@ def test_invalid_json(monkeypatch, capsys):
     result = get_pip_packages()
     assert result == []
 
+
 def test_command_fails(monkeypatch, capsys):
     """
     Test for case without a package manager
     """
+
     class FakeResult:
         def __init__(self):
             self.stdout = ""

--- a/tests/test_get_pip_packages.py
+++ b/tests/test_get_pip_packages.py
@@ -42,6 +42,12 @@ def test_poetry_fallback_message(monkeypatch, capsys):
     """
     Should print an error message if poetry is found but not pip or uv
     """
+    monkeypatch.setattr(shutil, "which", lambda cmd: cmd == "poetry")
+    result = get_pip_packages()
+    captured = capsys.readouterr()
+    assert "poetry" in captured.out
+    assert "poetry export" in captured.out
+    assert result == []
 
 def test_conda_fallback_message(monkeypatch, capsys):
     """

--- a/tests/test_get_pip_packages.py
+++ b/tests/test_get_pip_packages.py
@@ -84,4 +84,17 @@ def test_invalid_json(monkeypatch, capsys):
     result = get_pip_packages()
     assert result == []
 
-    
+def test_command_fails(monkeypatch, capsys):
+    class FakeResult:
+        def __init__(self):
+            self.stdout = ""
+            self.stderr = "Simulated error output"
+            self.returncode = 1
+
+    monkeypatch.setattr(shutil, "which", lambda cmd: True)
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: FakeResult())
+
+    result = get_pip_packages()
+    captured = capsys.readouterr()
+    assert "Package manager command failed" in captured.out
+    assert result == []

--- a/tests/test_get_pip_packages.py
+++ b/tests/test_get_pip_packages.py
@@ -28,6 +28,15 @@ def test_pip_installed_if_uv_not_found(monkeypatch):
     """
     Should fallback to 'pip list' if uv is not found
     """
+    monkeypatch.setattr(shutil, "which", lambda cmd: cmd == "pip")
+
+    def fake_run(*args, **kwargs):
+        return FakeResult('[{"name": "bar", "version": "2.0.0"}]', 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = get_pip_packages()
+    assert result == [{"name": "bar", "version": "2.0.0"}]
 
 def test_poetry_fallback_message(monkeypatch, capsys):
     """

--- a/tests/test_get_pip_packages.py
+++ b/tests/test_get_pip_packages.py
@@ -64,6 +64,11 @@ def test_nothing_found(monkeypatch, capsys):
     """
     Should print an error if no tool is found
     """
+    monkeypatch.setattr(shutil, "which", lambda cmd: False)
+    result = get_pip_packages()
+    captured = capsys.readouterr()
+    assert "No supported package manager" in captured.out
+    assert result == []
 
 def test_invalid_json(monkeypatch, capsys):
     """

--- a/tests/test_get_pip_packages.py
+++ b/tests/test_get_pip_packages.py
@@ -114,7 +114,7 @@ def test_invalid_json(monkeypatch, capsys):
             return "/usr/local/bin/uv"
         return None
     
-    def fake_run(cmd, captured_output=True, text=True):
+    def fake_run(cmd, capture_output=True, text=True):
         class FakeResult:
             stdout = "Not JSON"
         return FakeResult()

--- a/tests/test_get_pip_packages.py
+++ b/tests/test_get_pip_packages.py
@@ -85,6 +85,9 @@ def test_invalid_json(monkeypatch, capsys):
     assert result == []
 
 def test_command_fails(monkeypatch, capsys):
+    """
+    Test for case without a package manager
+    """
     class FakeResult:
         def __init__(self):
             self.stdout = ""

--- a/uv.lock
+++ b/uv.lock
@@ -176,10 +176,33 @@ wheels = [
 ]
 
 [[package]]
+name = "depsize"
+version = "0.1.6"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "ipykernel" },
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "ruff", specifier = ">=0.11.12" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
@@ -224,6 +247,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
@@ -501,6 +533,32 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.51"
 source = { registry = "https://pypi.org/simple" }
@@ -555,31 +613,55 @@ wheels = [
 ]
 
 [[package]]
-name = "depsize"
-version = "0.1.0"
-source = { virtual = "." }
-
-[package.dev-dependencies]
-dev = [
-    { name = "ipykernel" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "ipykernel", specifier = ">=6.29.5" },
-    { name = "ruff", specifier = ">=0.11.12" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.9' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.9'" },
+    { name = "iniconfig", marker = "python_full_version < '3.9'" },
+    { name = "packaging", marker = "python_full_version < '3.9'" },
+    { name = "pluggy", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "tomli", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.9' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
+    { name = "iniconfig", marker = "python_full_version >= '3.9'" },
+    { name = "packaging", marker = "python_full_version >= '3.9'" },
+    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pygments", marker = "python_full_version >= '3.9'" },
+    { name = "tomli", marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
 ]
 
 [[package]]
@@ -766,6 +848,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload-time = "2024-11-27T22:37:54.956Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429, upload-time = "2024-11-27T22:37:56.698Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067, upload-time = "2024-11-27T22:37:57.63Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030, upload-time = "2024-11-27T22:37:59.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898, upload-time = "2024-11-27T22:38:00.429Z" },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894, upload-time = "2024-11-27T22:38:02.094Z" },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319, upload-time = "2024-11-27T22:38:03.206Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273, upload-time = "2024-11-27T22:38:04.217Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310, upload-time = "2024-11-27T22:38:05.908Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309, upload-time = "2024-11-27T22:38:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762, upload-time = "2024-11-27T22:38:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453, upload-time = "2024-11-27T22:38:09.384Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486, upload-time = "2024-11-27T22:38:10.329Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349, upload-time = "2024-11-27T22:38:11.443Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159, upload-time = "2024-11-27T22:38:13.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243, upload-time = "2024-11-27T22:38:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645, upload-time = "2024-11-27T22:38:15.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584, upload-time = "2024-11-27T22:38:17.645Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875, upload-time = "2024-11-27T22:38:19.159Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418, upload-time = "2024-11-27T22:38:20.064Z" },
+    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708, upload-time = "2024-11-27T22:38:21.659Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582, upload-time = "2024-11-27T22:38:22.693Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543, upload-time = "2024-11-27T22:38:24.367Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691, upload-time = "2024-11-27T22:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170, upload-time = "2024-11-27T22:38:27.921Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530, upload-time = "2024-11-27T22:38:29.591Z" },
+    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666, upload-time = "2024-11-27T22:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954, upload-time = "2024-11-27T22:38:31.702Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
In order to use depsize it must support the most used if not all tools used for installing and managing dependencies in python. In this branch I will try to support several systems, including popular options like pip and uv. 

Add support and error handling for 

- [x] pip
- [x] uv

Next candidates should be poetry and conda. It's harder to test for these, so for now I will explain how to run depsize with them.

Add some tests for the updated `get_pip_packages` method, so that you can test handling for cases where uv, pip, conda or poetry are missing, or all of them are missing.